### PR TITLE
Support explicit opt-in for HTTP (insecure) connections in addition to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,16 @@ Open VS Code settings (`Ctrl/Cmd + ,`) and configure:
   "s3x.region": "us-east-1",
 
   // Optional: Max file size for direct editing (default: 10MB)
-  "s3x.maxPreviewSizeBytes": 10485760
+  "s3x.maxPreviewSizeBytes": 10485760,
+  
+  // Optional: Explicitly allow insecure HTTP endpoints (NOT recommended for production, default: false)
+  "s3x.allowHttp": false  
 }
 ```
+
+⚠️ **Warning**:  
+The `s3x.allowHttp` option is intended **only for development or test environments on trusted networks**.  
+Never enable this option in production, as it allows unencrypted HTTP connections and may expose sensitive data.
 
 ### 3. Open the Explorer
 
@@ -170,16 +177,20 @@ https://<account-id>.<jurisdiction>.r2.cloudflarestorage.com
 
 ## ⚙️ Configuration Reference
 
-| Setting                   | Description                | Default       | R2 Required |
-| ------------------------- | -------------------------- | ------------- | ----------- |
-| `s3x.endpointUrl`         | S3-compatible endpoint URL | `""`          | ✅          |
-| `s3x.accessKeyId`         | Access Key ID              | `""`          | ✅          |
-| `s3x.secretAccessKey`     | Secret Access Key          | `""`          | ✅          |
-| `s3x.forcePathStyle`      | Use path-style URLs        | `true`        | ✅          |
-| `s3x.region`              | AWS region for SigV4       | `"us-east-1"` | ⚠️          |
-| `s3x.maxPreviewSizeBytes` | Max file size for editing  | `10485760`    | ❌          |
+| Setting                   | Description                                        | Default       | R2 Required |
+| ------------------------- | -------------------------------------------------- | ------------- | ----------- |
+| `s3x.endpointUrl`         | S3-compatible endpoint URL                         | `""`          | ✅           |
+| `s3x.accessKeyId`         | Access Key ID                                      | `""`          | ✅           |
+| `s3x.secretAccessKey`     | Secret Access Key                                  | `""`          | ✅           |
+| `s3x.forcePathStyle`      | Use path-style URLs                                | `true`        | ✅           |
+| `s3x.region`              | AWS region for SigV4                               | `"us-east-1"` | ⚠️          |
+| `s3x.maxPreviewSizeBytes` | Max file size for editing                          | `10485760`    | ❌           |
+| `s3x.allowHttp`           | Allow insecure HTTP connections (development only) | `false`       | ❌           |
 
-⚠️ **Note**: R2 works with any region, but `us-east-1` is recommended.
+⚠️ **Note**:
+
+- R2 works with any region, but `us-east-1` is recommended.
+- `s3x.allowHttp` should only be enabled in trusted **development/test environments**, never in production.
 
 ## 🔧 Commands
 
@@ -218,6 +229,7 @@ https://<account-id>.<jurisdiction>.r2.cloudflarestorage.com
 - **Token Rotation**: Regularly rotate API tokens
 - **Endpoint Verification**: Ensure endpoint URLs are correct
 - **HTTPS Only**: Extension enforces HTTPS for security
+- **Insecure Mode**: If `s3x.allowHttp` is enabled, connections will use plain HTTP. This should only be done on trusted internal networks for development or testing.
 
 ## 🛠️ Development
 
@@ -294,6 +306,11 @@ Run the built-in smoke test:
 - **Check URL format**: Must be `https://account.jurisdiction.r2.cloudflarestorage.com`
 - **Check network**: Verify internet connectivity
 - **Check firewall**: Ensure HTTPS traffic is allowed
+- **If using HTTP**:
+
+  * Ensure the endpoint starts with `http://`
+  * Set `"s3x.allowHttp": true` in your configuration
+  * Only use in trusted development/test networks
 
 #### "Files not opening"
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,11 @@
     "configuration": {
       "title": "S3/R2 Explorer",
       "properties": {
+        "s3x.allowHttp": {
+          "type": "boolean",
+          "default": false,
+          "description": "Allows HTTP (no TLS). Dangerous — use only in dev on trusted networks; may expose data and credentials."
+        },
         "s3x.endpointUrl": {
           "type": "string",
           "default": "",

--- a/src/s3/client.ts
+++ b/src/s3/client.ts
@@ -35,7 +35,11 @@ export function validateConfig(config: S3Config): string[] {
   }
 
   if (config.endpointUrl && !isValidUrl(config.endpointUrl, config.allowHttp)) {
-    errors.push("Endpoint URL must be a valid HTTPS URL");
+    errors.push(
+      config.allowHttp
+        ? "Endpoint URL must be a valid HTTP or HTTPS URL"
+        : "Endpoint URL must be a valid HTTPS URL (set s3x.allowHttp=true to allow HTTP)"
+    );
   }
 
   return errors;

--- a/src/s3/client.ts
+++ b/src/s3/client.ts
@@ -45,7 +45,7 @@ export function validateConfig(config: S3Config): string[] {
   return errors;
 }
 
-function isValidUrl(url: string, allowHttp: boolean): boolean {
+function isValidUrl(url: string, allowHttp: boolean = false): boolean {
   try {
     const parsed = new URL(url);
     return parsed.protocol === "https:" || (allowHttp && parsed.protocol === "http:");

--- a/src/s3/client.ts
+++ b/src/s3/client.ts
@@ -15,6 +15,7 @@ export function getConfig(): S3Config {
     secretAccessKey: config.get<string>("secretAccessKey", ""),
     forcePathStyle: config.get<boolean>("forcePathStyle", true),
     maxPreviewSizeBytes: config.get<number>("maxPreviewSizeBytes", 10485760),
+    allowHttp: config.get<boolean>("allowHttp", false),
   };
 }
 
@@ -33,17 +34,17 @@ export function validateConfig(config: S3Config): string[] {
     errors.push("Secret Access Key is required");
   }
 
-  if (config.endpointUrl && !isValidUrl(config.endpointUrl)) {
+  if (config.endpointUrl && !isValidUrl(config.endpointUrl, config.allowHttp)) {
     errors.push("Endpoint URL must be a valid HTTPS URL");
   }
 
   return errors;
 }
 
-function isValidUrl(url: string): boolean {
+function isValidUrl(url: string, allowHttp: boolean): boolean {
   try {
     const parsed = new URL(url);
-    return parsed.protocol === "https:";
+    return parsed.protocol === "https:" || (allowHttp && parsed.protocol === "http:");
   } catch {
     return false;
   }

--- a/src/test/suite/client.test.ts
+++ b/src/test/suite/client.test.ts
@@ -34,7 +34,6 @@ suite("S3 Client Tests", () => {
     assert.strictEqual(config.region, testConfig.region);
     assert.strictEqual(config.forcePathStyle, true);
     assert.strictEqual(config.maxPreviewSizeBytes, 10485760);
-    assert.strictEqual(config.allowHttp, testConfig.allowHttp);
   });
 
   test("validateConfig validates required fields", () => {
@@ -43,10 +42,9 @@ suite("S3 Client Tests", () => {
       endpointUrl: "https://example.r2.cloudflarestorage.com",
       region: "us-east-1",
       accessKeyId: "test-access-key",
-      secretAccessKey: "test-secret-key",
+      secretAccessKey: "test-secret-key", 
       forcePathStyle: true,
-      maxPreviewSizeBytes: 10485760,
-      allowHttp: false
+      maxPreviewSizeBytes: 10485760
     };
     const validErrors = validateConfig(validConfig);
     assert.strictEqual(validErrors.length, 0);
@@ -70,28 +68,6 @@ suite("S3 Client Tests", () => {
     const invalidUrlConfig = { ...validConfig, endpointUrl: "not-a-url" };
     const urlErrors = validateConfig(invalidUrlConfig);
     assert.ok(urlErrors.some((err) => err.includes("valid HTTPS URL")));
-
-    // HTTP URL with allowHttp = false should return error
-    const httpDisallowedConfig = {
-      ...validConfig,
-      endpointUrl: "http://minio.local:9000",
-      allowHttp: false
-    };
-    const httpDisallowedErrors = validateConfig(httpDisallowedConfig);
-    assert.ok(httpDisallowedErrors.some((err) => err.includes("valid HTTPS URL")));
-
-    // HTTP URL with allowHttp = true should be valid
-    const httpAllowedConfig = {
-      ...validConfig,
-      endpointUrl: "http://minio.local:9000",
-      allowHttp: true
-    };
-    const httpAllowedErrors = validateConfig(httpAllowedConfig);
-    assert.strictEqual(
-      httpAllowedErrors.length,
-      0,
-      "HTTP should be allowed when allowHttp is true"
-    );
   });
 
   test("getS3Client creates client with correct configuration", () => {
@@ -158,7 +134,7 @@ suite("S3 Client Tests", () => {
           case "secretAccessKey":
             return "";
           case "allowHttp":
-            return false; // default
+            return false;
           default:
             return defaultValue;
         }

--- a/src/test/suite/client.test.ts
+++ b/src/test/suite/client.test.ts
@@ -34,6 +34,7 @@ suite("S3 Client Tests", () => {
     assert.strictEqual(config.region, testConfig.region);
     assert.strictEqual(config.forcePathStyle, true);
     assert.strictEqual(config.maxPreviewSizeBytes, 10485760);
+    assert.strictEqual(config.allowHttp, testConfig.allowHttp);
   });
 
   test("validateConfig validates required fields", () => {
@@ -42,9 +43,10 @@ suite("S3 Client Tests", () => {
       endpointUrl: "https://example.r2.cloudflarestorage.com",
       region: "us-east-1",
       accessKeyId: "test-access-key",
-      secretAccessKey: "test-secret-key", 
+      secretAccessKey: "test-secret-key",
       forcePathStyle: true,
-      maxPreviewSizeBytes: 10485760
+      maxPreviewSizeBytes: 10485760,
+      allowHttp: false
     };
     const validErrors = validateConfig(validConfig);
     assert.strictEqual(validErrors.length, 0);
@@ -68,6 +70,28 @@ suite("S3 Client Tests", () => {
     const invalidUrlConfig = { ...validConfig, endpointUrl: "not-a-url" };
     const urlErrors = validateConfig(invalidUrlConfig);
     assert.ok(urlErrors.some((err) => err.includes("valid HTTPS URL")));
+
+    // HTTP URL with allowHttp = false should return error
+    const httpDisallowedConfig = {
+      ...validConfig,
+      endpointUrl: "http://minio.local:9000",
+      allowHttp: false
+    };
+    const httpDisallowedErrors = validateConfig(httpDisallowedConfig);
+    assert.ok(httpDisallowedErrors.some((err) => err.includes("valid HTTPS URL")));
+
+    // HTTP URL with allowHttp = true should be valid
+    const httpAllowedConfig = {
+      ...validConfig,
+      endpointUrl: "http://minio.local:9000",
+      allowHttp: true
+    };
+    const httpAllowedErrors = validateConfig(httpAllowedConfig);
+    assert.strictEqual(
+      httpAllowedErrors.length,
+      0,
+      "HTTP should be allowed when allowHttp is true"
+    );
   });
 
   test("getS3Client creates client with correct configuration", () => {
@@ -133,6 +157,8 @@ suite("S3 Client Tests", () => {
             return "";
           case "secretAccessKey":
             return "";
+          case "allowHttp":
+            return false; // default
           default:
             return defaultValue;
         }

--- a/src/test/test-config.ts
+++ b/src/test/test-config.ts
@@ -6,6 +6,7 @@ export interface TestConfig {
   secretAccessKey: string;
   region: string;
   testBucketPrefix: string;
+  allowHttp?: boolean;
 }
 
 /**
@@ -19,6 +20,7 @@ export function getTestConfig(): TestConfig {
     secretAccessKey: process.env.S3X_SECRET_ACCESS_KEY || "",
     region: process.env.S3X_REGION || "us-east-1",
     testBucketPrefix: "s3x-test-ci",
+    allowHttp: false,
   };
 }
 

--- a/src/test/test-config.ts
+++ b/src/test/test-config.ts
@@ -6,7 +6,6 @@ export interface TestConfig {
   secretAccessKey: string;
   region: string;
   testBucketPrefix: string;
-  allowHttp?: boolean;
 }
 
 /**
@@ -20,7 +19,6 @@ export function getTestConfig(): TestConfig {
     secretAccessKey: process.env.S3X_SECRET_ACCESS_KEY || "",
     region: process.env.S3X_REGION || "us-east-1",
     testBucketPrefix: "s3x-test-ci",
-    allowHttp: false,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export interface S3Config {
   secretAccessKey: string;
   forcePathStyle: boolean;
   maxPreviewSizeBytes: number;
-  allowHttp: boolean;
+  allowHttp?: boolean;
 }
 
 export interface S3Object {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface S3Config {
   secretAccessKey: string;
   forcePathStyle: boolean;
   maxPreviewSizeBytes: number;
+  allowHttp: boolean;
 }
 
 export interface S3Object {


### PR DESCRIPTION
Allows unencrypted HTTP connections in development environments on trusted networks. Adds conditional validation for http/https protocols based on the flag.

Closes: #2